### PR TITLE
feat: add auth decorators to all endpoints in controller dir

### DIFF
--- a/app/main/aad/auth_decorators.py
+++ b/app/main/aad/auth_decorators.py
@@ -60,12 +60,14 @@ class AuthDecorator:
                     roles = decoded_token['roles']
                     
                     # Check if the user's role is allowed
-                    authenticated = False
-                    for i in roles:
-                        for j in allowed_roles:
-                            if i == j:
-                                authenticated = True
-                                break
+                    # could we do: 
+                    authenticated = any(role in allowed_roles for role in roles)
+                    # authenticated = False
+                    # for i in roles:
+                    #     for j in allowed_roles:
+                    #         if i == j:
+                    #             authenticated = True
+                    #             break
                     
                     if not authenticated:
                         # Return a 401 Unauthorized response

--- a/app/main/controller/file_controller.py
+++ b/app/main/controller/file_controller.py
@@ -2,8 +2,11 @@ from flask import request
 from flask_restx import Resource
 from werkzeug.utils import secure_filename
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service.file_service import *
 from ..util.dto import FileDto, FilesDto
+
+auth_decorator = AuthDecorator()
 
 api = FileDto.api
 files_api = FilesDto.files_api
@@ -13,6 +16,9 @@ files_api = FilesDto.files_api
 class GetSasToken(Resource):
     @api.doc(description="Get a SAS token for the blob")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, filename):
         sas_token, endpoint, endpoint_without_sas_token = get_write_sas_token(filename)
 
@@ -26,6 +32,9 @@ class GetSasToken(Resource):
 class GetReadSasToken(Resource):
     @api.doc(description="Get a SAS token for the blob")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, filename):
         sas_token, endpoint, endpoint_without_sas_token = get_read_sas_token(filename)
 

--- a/app/main/controller/gdal_info_controller.py
+++ b/app/main/controller/gdal_info_controller.py
@@ -1,8 +1,11 @@
 from flask import request
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service.gdal_info_service import *
 from ..util.dto import GdalInfoDto
+
+auth_decorator = AuthDecorator()
 
 api = GdalInfoDto.api
 
@@ -15,6 +18,9 @@ class GdalInfo(Resource):
     @api.response(200, "Success")
     @api.response(404, "File not found")
     @api.response(500, "Internal server error")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         file_path = request.json["file_url"]
         try:

--- a/app/main/controller/private_catalog_controller.py
+++ b/app/main/controller/private_catalog_controller.py
@@ -1,12 +1,15 @@
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List
 
 from flask import request
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..custom_exceptions import *
 from ..service import private_catalog_service
 from ..service import stac_service
 from ..util.dto import PrivateCatalogDto
+
+auth_decorator = AuthDecorator()
 
 api = PrivateCatalogDto.api
 collections = PrivateCatalogDto.collection
@@ -17,6 +20,9 @@ collections = PrivateCatalogDto.collection
 class Collections(Resource):
     @api.doc(description='Search for collections in all catalogs')
     @api.response(200, 'Success')
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         spatial_extent: List[float] = request.json['bbox']
         temporal_extent: str = request.json['datetime']
@@ -29,6 +35,9 @@ class CollectionsList(Resource):
     @api.expect(PrivateCatalogDto.collection_dto, validate=True)
     @api.response(200, "Success")
     @api.response(400, "Validation Error")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         try:
             return private_catalog_service.add_collection(request.json)
@@ -47,6 +56,9 @@ class CollectionsList(Resource):
     @api.response(400, "Validation Error")
     @api.response(404, "Collection not found")
     @api.response("4xx", "Stac API reported error")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def put(self):
         try:
             return private_catalog_service.update_collection(request.json), 200
@@ -68,6 +80,9 @@ class Collection(Resource):
     @api.doc(description="Remove private collection by id")
     @api.response(200, "Collection removed successfully.")
     @api.response(404, "Collection not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self, collection_id: str) -> Tuple[Dict[str, str], int]:
         try:
             return private_catalog_service.remove_collection(collection_id), 200
@@ -85,6 +100,9 @@ class CollectionItems(Resource):
     @api.response(403, "Unauthorized.")
     @api.response("4xx", "Stac API reported error")
     @api.expect(PrivateCatalogDto.item_dto, validate=True)
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self, collection_id):
         print(request.data)
         try:
@@ -110,6 +128,9 @@ class CollectionItem(Resource):
     @api.response(200, "Success")
     @api.response(403, "Unauthorized.")
     @api.expect(PrivateCatalogDto.item_dto, validate=True)
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def put(self, collection_id: str, item_id: str):
         try:
             return stac_service.update_item_in_collection_on_stac_api(collection_id, item_id, request.json), 200
@@ -126,6 +147,9 @@ class CollectionItem(Resource):
     @api.response(200, "Success")
     @api.response(403, "Unauthorized.")
     @api.response("4xx", "Stac API reported error")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self, collection_id: str, item_id: str):
         try:
             return stac_service.remove_item_from_collection_on_stac_api(collection_id, item_id), 200

--- a/app/main/controller/public_catalogs_contoller.py
+++ b/app/main/controller/public_catalogs_contoller.py
@@ -28,6 +28,9 @@ class PublicCatalogs(Resource):
     @api.response(201, "Success")
     @api.response(400, "Validation Error - Some elements are missing")
     @api.response(409, "Conflict - Catalog already exists")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         try:
             data = request.json
@@ -51,6 +54,9 @@ class PublicCatalogs(Resource):
 
     @api.doc(description="Delete all public catalogs from the database")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self):
         public_catalogs_service.remove_all_public_catalogs()
         return {"message": "Deleted all catalogs"}, 200
@@ -60,6 +66,9 @@ class PublicCatalogs(Resource):
 class PublicCatalogsUpdate(Resource):
     @api.doc(description="Get all public catalogs and update them")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self):
         public_catalogs_service.store_publicly_available_catalogs()
         return {"message": "Sync operation started"}, 200
@@ -69,6 +78,9 @@ class PublicCatalogsUpdate(Resource):
 class PublicCatalogsCollections(Resource):
     @api.doc("Get all public collections stored in the database")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self):
         return (
             public_catalogs_service.get_all_stored_public_collections_as_list_of_dict()
@@ -80,6 +92,9 @@ class PublicCatalogsCollections(Resource):
     @api.doc(description="Get all collections of all public catalogs")
     @api.response(200, "Success")
     @api.expect(PublicCatalogsDto.collection_search, validate=True)
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         spatial_extent: List[float] = request.json["bbox"]
         temporal_extent: str = request.json["datetime"]
@@ -97,6 +112,9 @@ class SpecificPublicCatalogCollections(Resource):
     @api.response(200, "Success")
     @api.response(404, "Not Found - Catalog does not exist")
     @api.expect(PublicCatalogsDto.collection_search, validate=True)
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self, public_catalog_id):
         spatial_extent: List[float] = request.json["bbox"]
         temporal_extent: str = request.json["datetime"]
@@ -117,6 +135,9 @@ class PublicCatalogLoadHistory(Resource):
     @api.doc(description="Get load history for specified public catalog")
     @api.response(200, "Success")
     @api.response(404, "Not Found - Catalog does not exist")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, public_catalog_id):
         try:
             return (
@@ -136,6 +157,9 @@ class PublicCatalogCollections(Resource):
     @api.doc(description="Get all collections for specified public catalog")
     @api.response(200, "Success")
     @api.response(404, "Not Found - Catalog does not exist")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, public_catalog_id):
         try:
             return (
@@ -155,6 +179,9 @@ class SpecificPublicCatalogCollection(Resource):
     @api.doc(description="Get specified collection for specified public catalog")
     @api.response(200, "Success")
     @api.response(404, "Not Found - Catalog or collection does not exist")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self, public_catalog_id, collection_id):
         try:
             public_catalogs_service.remove_collection_from_public_catalog(
@@ -178,6 +205,9 @@ class PublicCatalogsViaId(Resource):
     @api.doc(description="""Get the details of a public catalog by its id.""")
     @api.response(200, "Success")
     @api.response(404, "Public catalog not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, public_catalog_id):
         try:
             return public_catalogs_service.get_public_catalog_by_id_as_dict(
@@ -190,6 +220,9 @@ class PublicCatalogsViaId(Resource):
     @api.doc(description="Remove a public catalog via its id")
     @api.response(200, "Success")
     @api.response(404, "Public catalog not found so it cant be removed")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self, public_catalog_id):
         try:
             return public_catalogs_service.remove_public_catalog_via_catalog_id(
@@ -204,6 +237,9 @@ class GetStacRecordsSpecifyingPublicCatalogId(Resource):
     @api.doc(description="""Get specific collections from catalog.""")
     @api.expect(PublicCatalogsDto.start_stac_ingestion, validate=True)
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self, public_catalog_id):
         data = request.json
         try:
@@ -224,6 +260,9 @@ class GetStacRecordsSpecifyingPublicCatalogId(Resource):
 @api.route("/items/update/")
 class UpdateAllStacRecords(Resource):
     @api.doc(description="Update all stored stac records from all public catalogs")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self):
         try:
             result = public_catalogs_service.update_all_stac_records()
@@ -246,6 +285,9 @@ class UpdateStacRecordsSpecifyingPublicCatalogId(Resource):
     @api.doc(description="""Get all stac records from a public catalog.""")
     @api.response(200, "Success")
     @api.response(404, "Public catalog not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, public_catalog_id):
         try:
             return public_catalogs_service.update_specific_collections_via_catalog_id(
@@ -263,6 +305,9 @@ class UpdateStacRecordsSpecifyingPublicCatalogId(Resource):
         PublicCatalogsDto.update_stac_collections_specify_collection_ids, validate=True
     )
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self, public_catalog_id):
         collections_to_update = request.json["collections"]
         try:
@@ -289,6 +334,9 @@ class UpdateStacRecordsSpecifyingPublicCatalogId(Resource):
 class RunSearchParameters(Resource):
     @api.doc(description="Run search parameters for specified public catalog")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, parameter_id):
         try:
             return public_catalogs_service.run_search_parameters(parameter_id), 200

--- a/app/main/controller/stac_controller.py
+++ b/app/main/controller/stac_controller.py
@@ -1,7 +1,10 @@
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service.stac_service import *
 from ..util.dto import StacDto
+
+auth_decorator = AuthDecorator()
 
 api = StacDto.api
 
@@ -10,6 +13,9 @@ api = StacDto.api
 class CollectionsList(Resource):
     @api.doc(description="List all collections on the stac-api server")
     @api.response(200, "Success")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self):
         return get_all_collections(), 200
 
@@ -19,6 +25,9 @@ class Collection(Resource):
     @api.doc(description="get_collection")
     @api.response(200, "Success")
     @api.response(404, "Collection not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, collection_id: str):
         try:
             return get_collection_by_id(collection_id), 200
@@ -34,6 +43,9 @@ class CollectionItems(Resource):
     @api.doc(description="get_collection_items")
     @api.response(200, "Success")
     @api.response(404, "Collection not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, collection_id: str) -> Tuple[Dict[str, str], int]:
         try:
             return get_items_by_collection_id(collection_id), 200
@@ -50,6 +62,9 @@ class CollectionItem(Resource):
     @api.response(200, "Success")
     @api.response(404, "Collection not found")
     @api.response(404, "Item not found")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, collection_id: str,
             item_id: str) -> Tuple[Dict[str, str], int]:
         try:

--- a/app/main/controller/stac_generator_controller.py
+++ b/app/main/controller/stac_generator_controller.py
@@ -3,8 +3,11 @@ import logging
 from flask import request
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service.stac_generator_service import create_STAC_Item
 from ..util.dto import StacGeneratorDto
+
+auth_decorator = AuthDecorator()
 
 api = StacGeneratorDto.api
 
@@ -21,6 +24,9 @@ class StacGenerator(Resource):
     @api.response(200, "Success")
     @api.response(404, "File not found")
     @api.response(500, "Internal server error")
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         """
         The POST method for the STAC Generator resource.

--- a/app/main/controller/status_reporting_controller.py
+++ b/app/main/controller/status_reporting_controller.py
@@ -1,8 +1,11 @@
 import sqlalchemy
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service import status_reporting_service
 from ..util.dto import StatusReportingDto
+
+auth_decorator = AuthDecorator()
 
 api = StatusReportingDto.api
 
@@ -10,6 +13,9 @@ api = StatusReportingDto.api
 @api.route('/loading_public_stac_records/')
 class StacIngestionStatus(Resource):
     @api.doc(description='Get all statuses of stac ingestion statuses')
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self):
         return status_reporting_service.get_all_stac_ingestion_statuses()
 
@@ -17,6 +23,9 @@ class StacIngestionStatus(Resource):
 @api.route('/loading_public_stac_records/<string:status_id>/')
 class StacIngestionStatusViaId(Resource):
     @api.doc(description='get a stac ingestion status via status_id')
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Viewer", "StacPortal.Creator"]
+    )
     def get(self, status_id):
         try:
             return status_reporting_service.get_stac_ingestion_status_by_id(
@@ -25,7 +34,11 @@ class StacIngestionStatusViaId(Resource):
             return {'message': 'No result found'}, 404
 
     @api.doc(
-        description='Delete a stac ingestion status with specified status_id')
+        description='Delete a stac ingestion status with specified status_id'
+    )
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def delete(self, status_id):
         try:
             return status_reporting_service.remove_stac_ingestion_status_entry(

--- a/app/main/controller/validate_controller.py
+++ b/app/main/controller/validate_controller.py
@@ -1,8 +1,11 @@
 from flask import request
 from flask_restx import Resource
 
+from ..aad.auth_decorators import AuthDecorator
 from ..service.validate_service import validate_json
 from ..util.dto import ValidateDto
+
+auth_decorator = AuthDecorator()
 
 api = ValidateDto.api
 validate = ValidateDto.validate
@@ -12,6 +15,9 @@ validate = ValidateDto.validate
 class ValidateJSON(Resource):
     @api.doc("validate_json")
     @api.expect(validate)
+    @auth_decorator.header_decorator(
+        allowed_roles=["StacPortal.Creator"]
+    )
     def post(self):
         data = request.json
         resp, status = validate_json(data=data)


### PR DESCRIPTION
added auth decorators to all endpoints in the controller dir, with viewer and creator users allowed to use any get requests and only creator users authorised for all other requests